### PR TITLE
Compatibility with Tapeline mod

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -3,6 +3,7 @@ Version: 1.0.6
 Date: ??. ??. ????
   Bugfixes:
     - Ignore ghost entitites that are marked as non-selectable. Fixes phantom ghosts when used with Tapeline mod. Permanent tapelines would leave "phantom" ghosts otherwise.
+    - Do not auto-approve ghosts when using selection tools that place entities that are not selectable in the game. Those are usually used for special purposes by mods that build them. Fixes issues with selection tool from Tapeline mod approving the ghosts when dragged over them.
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.5
 Date: 17. 10. 2021

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.6
+Date: ??. ??. ????
+  Bugfixes:
+    - Ignore ghost entitites that are marked as non-selectable. Fixes phantom ghosts when used with Tapeline mod. Permanent tapelines would leave "phantom" ghosts otherwise.
+---------------------------------------------------------------------------------------------------
 Version: 1.0.5
 Date: 17. 10. 2021
   Features:

--- a/src/control.lua
+++ b/src/control.lua
@@ -480,6 +480,17 @@ script.on_event(defines.events.on_pre_build,
     -- before the build happens.  This restores the ghost to the main force so that any special logic like recipe
     -- preservation will be handled properly when the entity gets built.
     local player = game.players[event.player_index]
+
+    -- Selection tools can be used to build entities as they are being dragged across the screen. If player is building
+    -- entities with a selection tool, make sure to validate that the selection tool places entities that are selectable
+    -- before approving the underlying unapproved ghosts. Tapeline is an example of a mod that behaves in this manner.
+    -- Unfortunately, it does not seem possible to more closely detect what entity would get placed during this event.
+    local cursor_stack = player.cursor_stack
+    if cursor_stack and cursor_stack.is_selection_tool and
+      cursor_stack.prototype.place_result and not cursor_stack.prototype.place_result.selectable_in_game then
+      return
+    end
+
     local unapproved_ghost_force_name = to_unapproved_ghost_force_name(player.force.name)
     if game.forces[unapproved_ghost_force_name] then
       local unapproved_ghosts = player.surface.find_entities_filtered {

--- a/src/control.lua
+++ b/src/control.lua
@@ -219,7 +219,11 @@ function is_approvable_ghost(entity)
     return entity.time_to_live < UINT32_MAX
   end
 
-  return entity and entity.type == "entity-ghost" and not is_placeholder(entity) and not is_perishable(entity)
+  function is_selectable(entity)
+    return entity.type == "entity-ghost" and entity.ghost_prototype.selectable_in_game
+  end
+
+  return entity and entity.type == "entity-ghost" and not is_placeholder(entity) and not is_perishable(entity) and is_selectable(entity)
 end
 
 function approve_entities(entities)


### PR DESCRIPTION
The purpose of this pull request is to fix compatibility with the [Tapeline](https://mods.factorio.com/mod/Tapeline) mod.

Tapeline mode creates temporary entities as player is drawing the tapelines using the tapeline selection tool.

When such entities are placed when auto-approvals are disabled by Construction Planner, they end-up being picked up as normal ghosts, and leave "phantom" ghost placeholders that can never be built. This problem is solved by adding checks to Construction Planner to see if the ghosts are marked as selectable (Tapeline marks such entities as non-selectable).

The other problem is when Tapeline is dragged over the existing unapproved ghosts. In that case the unapproved ghosts are approved by mistake during the invocation of `on_pre_build` event handler (as Tapeline's ghost entities are getting built on the surface). This one is a bit trickier to fix, but I think the proposed commit should be a good enough solution (checking if player is holding selection tool and if that selection tools places non-selectable entities/ghosts).